### PR TITLE
Support for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
   - "stable"
-  
+
+branches:
+  only:
+    - gh-pages
+    - master
+
 before_script:
   - npm install -g gulp
 script: gulp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: node_js
 node_js:
-  - "stable"
+  - 4.1
+  - 4.0
 
 branches:
   only:
     - gh-pages
-    - master
 
 before_script:
   - npm install -g gulp
+  
 script: gulp

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Met Us: Meetup.com growth tracker
 ![Travis build status](https://travis-ci.org/anyweez/metus.svg)
+
 Simple tool for visualizing growth curves for Meetup organizations. Uses the official Meetup.com API and [Chartist](https://gionkunz.github.io/chartist-js/) to visualize growth curves for Meetup groups over time.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,13 @@
     "chartist": "^0.9.4",
     "chartist-plugin-axistitle": "0.0.1",
     "gulp": "^3.9.0",
+    "gulp-browserify": "^0.5.1",
+    "gulp-concat": "^2.6.0",
+    "gulp-debug": "^2.1.2",
+    "gulp-jade": "^1.1.0",
     "gulp-mocha": "^2.1.3",
+    "gulp-sass": "^2.1.0",
+    "merge2": "^0.3.6",
     "mocha": "^2.3.3",
     "moment": "^2.10.6"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chai": "^3.4.0",
     "chartist": "^0.9.4",
     "chartist-plugin-axistitle": "0.0.1",
+    "gulp": "^3.9.0",
     "gulp-mocha": "^2.1.3",
     "mocha": "^2.3.3",
     "moment": "^2.10.6"


### PR DESCRIPTION
Building using `gulp`, which also runs Mocha test suite. Succesful build should confirm that all serving assets are being produced as operating as expected now.
